### PR TITLE
feat(huefy/shades): customize window position

### DIFF
--- a/doc/minty.txt
+++ b/doc/minty.txt
@@ -45,6 +45,17 @@ CONTENTS                                                      *minty.contents*
      mappings = function(bufs) -- bufs is a table cuz 2 bufs!
         -- add your mappings here ( buffer scoped )
      end
+
+     -- You can pass these fields in your personal configuration
+     -- to customize where the window will show.
+     -- See `:h nvim_open_win()` for how to configure these options
+     -- Not all options are supported, only the ones below
+
+     -- relative = "editor",
+     -- position = {
+     --   row = 5,
+     --   col = 20,
+     -- },
    },
 
   shades = {
@@ -53,6 +64,17 @@ CONTENTS                                                      *minty.contents*
       -- add your mappings here ( buffer scoped )
       -- local api = require("minty.shades.api")
       -- vim.keymap.set("n", "s", api.save_color, { buffer = buf })
+
+      -- You can pass these fields in your personal configuration
+      -- to customize where the window will show.
+      -- See `:h nvim_open_win()` for how to configure these options
+      -- Not all options are supported, only the ones below
+
+      -- relative = "editor",
+      -- position = {
+      --   row = 5,
+      --   col = 20,
+      -- },
     end
     },
  }

--- a/lua/minty/huefy/init.lua
+++ b/lua/minty/huefy/init.lua
@@ -54,13 +54,13 @@ M.open = function()
   end
 
   local win = api.nvim_open_win(v.palette_buf, true, {
-    row = 1,
-    col = fallback_col or 1,
+    row = config.position and config.position.row or 1,
+    col = config.position and config.position.col or (fallback_col or 1),
     -- row = (vim.o.lines / 2) / 2,
     -- col = vim.o.columns / 5,
     width = v.w,
     height = h,
-    relative = "cursor",
+    relative = config.relative and config.relative or "cursor",
     style = "minimal",
     border = "single",
     title = { { " 󱥚  Color picker ", border and "lazyh1" or "ExBlack3bg" } },

--- a/lua/minty/shades/init.lua
+++ b/lua/minty/shades/init.lua
@@ -28,11 +28,11 @@ M.open = function()
   local h = mark_state[v.buf].h
 
   local win = api.nvim_open_win(v.buf, true, {
-    row = 1,
-    col = 0,
+    row = config.position and config.position.row or 1,
+    col = config.position and config.position.col or 0,
     width = v.w,
     height = h,
-    relative = "cursor",
+    relative = config.relative and config.relative or "cursor",
     style = "minimal",
     border = { "┏", "━", "┓", "┃", "┛", "━", "┗", "┃" },
     title = { { " 󱥚 Color Shades ", "ExBlack3bg" } },


### PR DESCRIPTION
Make window position for `huefy` and `shades` customizable by user in his personal configuration. Only the first window has to be modified, since the others get created off of his position.

Really simple approach to expose most relevant `nvim_open_win()` fields in user's personal configuration and take it into consideration when creating the windows if they exist.

Feel free to disregard if you have something else in mind. :smile: 

Closes #9 